### PR TITLE
Add Makefile and fix test compilation on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .vs/
 Debug/
 Release/
+*.o
+*.a
+*.so
+test

--- a/NibbleAndAHalf/Makefile
+++ b/NibbleAndAHalf/Makefile
@@ -18,7 +18,7 @@ test: $(test_objects)
 	$(CC) -c $(OPTIMIZATION) $(CFLAGS) -o $@ $<
 
 libnaah64.so: base64.h base64.o
-	$(CC) -shared $^ -o $@
+	$(CC) -shared -o $@ base64.o
 
 libnaah64.a: base64.o
 	ar cr $@ $+

--- a/NibbleAndAHalf/Makefile
+++ b/NibbleAndAHalf/Makefile
@@ -1,0 +1,33 @@
+CC ?= gcc
+DIR ?= .
+
+CFLAGS ?= -fstack-protector-strong -Wall -Wextra -Wformat -Werror=format-security \
+	-D_FORTIFY_SOURCE=2 -fPIC
+LDFLAGS ?= -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -pie -L$(DIR) -lc
+OPTIMIZATION ?= -O3
+
+test_objects = main.o base64.o Timer.o testbase64.o
+
+nibble-and-a-half: libnaah64.so libnaah64.a
+
+test: $(test_objects)
+	$(CC) $(CFLAGS) $(test_objects) -o $(DIR)/test $(LDFLAGS)
+	chmod +x $(DIR)/test
+
+%.o: %.c
+	$(CC) -c $(OPTIMIZATION) $(CFLAGS) -o $@ $<
+
+libnaah64.so: base64.h base64.o
+	$(CC) -shared $^ -o $@
+
+libnaah64.a: base64.o
+	ar cr $@ $+
+
+.PHONY: clean install nibble-and-a-half
+
+install: nibble-and-a-half
+	cp $(DIR)/libnaah64.a ~/.local/lib/
+	cp $(DIR)/libnaah64.so ~/.local/lib/
+
+clean:
+	rm -rf $(DIR)/libnaah64.a $(DIR)/libnaah64.so $(DIR)/test $(test_objects)

--- a/NibbleAndAHalf/Timer.c
+++ b/NibbleAndAHalf/Timer.c
@@ -1,5 +1,7 @@
 #include "Timer.h"
 
+#include <stddef.h>
+
 void CTimerReset( CTimer* ctimer ) {
   #ifdef _WIN32
   QueryPerformanceCounter( &ctimer->startTime ) ;

--- a/NibbleAndAHalf/main.c
+++ b/NibbleAndAHalf/main.c
@@ -19,15 +19,15 @@
 
 int main( int argc, char** argv )
 {
-  //printUnbase64();  // Generate the unbase64 conversion array
+  printUnbase64();  // Generate the unbase64 conversion array
   
-  //testBase64String( "hi there aardvark!! @#$**&^)" );
-  //testBase64String( "" ); // sweet empty string test case
+  testBase64String( "hi there aardvark!! @#$**&^)" );
+  testBase64String( "" ); // sweet empty string test case
   
-  //testUnbase64WithBadAscii();
+  testUnbase64WithBadAscii();
   testUnbase64WithBadLength();
   
-  //automatedTests();
+  automatedTests();
   
   return 0;
 }

--- a/NibbleAndAHalf/testbase64.c
+++ b/NibbleAndAHalf/testbase64.c
@@ -2,6 +2,7 @@
 #include "base64.h"
 
 #include <string.h>
+#include <time.h>
 
 int BASE64TESTSHOWDATA = 0;
 int SHOWTIMING = 0;
@@ -119,7 +120,7 @@ void testUnbase64WithBadAscii()
   if( !base64integrity( badAscii, badAsciiLen ) )
   {
     puts( "<< EXPECTED >> There are some invalid ascii characters in your base64 string" );
-    int baddatLen;
+    int baddatLen = 0;
     unsigned char *baddat = unbase64( badAscii, badAsciiLen, &baddatLen );
     
     printf( "The unbase64'd data is %d bytes, anyway, it is:\n", baddatLen );


### PR DESCRIPTION
- Added Makefile with test and lib targets
- Added `#include <stddef.h>` to `Timer.c` for explicit `NULL` definition
- Added `#include <time.h>` to `testbase64.c` for explicit `time()` definition
- Initialize `int baddatLen` in `testUnbase64WithBadAscii()` function to avoid segmentation fault when running with other tests
- Uncommented all test function calls in `main()`