### PR TITLE
Add License file

### DIFF
--- a/License
+++ b/License
@@ -1,0 +1,24 @@
+https://github.com/superwills/NibbleAndAHalf -- Fast base64 encoding and decoding.
+version 1.0.1, Feb 1, 2022 812a
+
+Copyright (C) 2013 William Sherif
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software
+    in a product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+    misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+William Sherif
+
+YWxsIHlvdXIgYmFzZSBhcmUgYmVsb25nIHRvIHVz


### PR DESCRIPTION
Pulled out of #11.

I think it would be beneficial to have a clear project level license; Unless the omission is intentional.

Changes:
- Added License file
  - Copied directly from: https://github.com/superwills/NibbleAndAHalf/blob/c3d5edba42cb3e1fb91638aed79d3d5f9b371ffe/NibbleAndAHalf/base64.h#L3-L26
